### PR TITLE
update correct way to handle redirect after setting formstate in sign…

### DIFF
--- a/app/actions/logIn.ts
+++ b/app/actions/logIn.ts
@@ -2,28 +2,25 @@
 
 import { signIn } from "@/auth";
 import { AuthError } from "next-auth";
-
-import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
 
 export type FormState = {
   status: "success" | "error" | "pending";
 };
 
 export const login = async (formState: FormState, formData: FormData) => {
-	try {
+  try {
     formState.status = "success";
     await signIn("credentials", formData);
   } catch (error) {
-		console.log(error);
     if (error instanceof AuthError) formState.status = "error";
+  } finally {
+    if (formState.status === "success") {
+      redirect("/");
+    }
   }
-  // formState.status = "success";
-  // const signin = await signIn("credentials", formData);
-	// console.log(signin);
-
-  // revalidatePath("/", "layout");
 
   return {
-    status: formState.status,
+    status: formState.status
   };
 };

--- a/app/components/SignIn/Form.tsx
+++ b/app/components/SignIn/Form.tsx
@@ -9,10 +9,8 @@ import Button from "../global/Button";
 
 const SignInForm = () => {
   const [formState, action] = useFormState(login, {
-    status: "pending" as FormState["status"],
+    status: "pending" as FormState["status"]
   });
-
-  formState.status === "success" && redirect("/");
 
   return (
     <div>


### PR DESCRIPTION
Ok, this fixes the issue of Pendo not tracking, while not screwing up the login flow if a user's credentials are wrong.  I'm still seeing the user's info get updated automatically after sign in, while preserving the incorrect login.