### PR TITLE
Fix Pendo Initialization

### DIFF
--- a/app/components/Pendo/embed.ts
+++ b/app/components/Pendo/embed.ts
@@ -1,0 +1,43 @@
+import { useEffect } from "react";
+
+export default function PendoScript({ session }: any) {
+  useEffect(() => {
+    if (session) {
+      const emailAddress = session?.user?.email
+          ? session.user.email
+          : "Not Logged In";
+      const name = session?.user?.name ? session.user.name : "Not Logged In";
+      const userId = session?.user?.id ? session.user.id : "Not Logged In";
+
+      const script = document.createElement("script");
+      script.id = "pendo-script";
+      script.type = "text/javascript";
+      script.async = true;
+      script.defer = true;
+      script.innerHTML = `
+        (function(apiKey){
+          (function(p,e,n,d,o){var v,w,x,y,z;o=p[d]=p[d]||{};o._q=o._q||[];
+          v=['initialize','identify','updateOptions','pageLoad','track'];for(w=0,x=v.length;w<x;++w)(function(m){
+            o[m]=o[m]||function(){o._q[m===v[0]?'unshift':'push']([m].concat([].slice.call(arguments,0)));};})(v[w]);
+            y=e.createElement(n);y.async=!0;y.src='https://cdn.pendo.io/agent/static/'+apiKey+'/pendo.js';
+            z=e.getElementsByTagName(n)[0];z.parentNode.insertBefore(y,z);})(window,document,'script','pendo');
+
+          pendo.initialize({
+            visitor: {
+              id: "${userId}",
+              email: "${emailAddress}",
+              firstName: "${name}",
+            },
+            account: {
+              id: "${process.env.PENDO_ACCOUNT_ID}",
+              accountName: "SIR Digital Hub",
+            }
+          });
+        })('${process.env.PENDO_API_KEY}');
+      `;
+      document.body.appendChild(script);
+    }
+  }, [session]);
+
+  return null;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import { Gloock, Roboto, Bitter } from "next/font/google";
 import { GoogleAnalytics } from "@next/third-parties/google";
 
 import HubspotTracking from "@/app/components/Hubspot/embed";
+import PendoScript from "@/app/components/Pendo/embed";
 
 import "./globals.css";
 
@@ -39,11 +40,7 @@ export default async function RootLayout({
   children: React.ReactNode;
 }>) {
   const session = await auth();
-  const emailAddress = session?.user?.email
-    ? session.user.email
-    : "Not Logged In";
-  const name = session?.user?.name ? session.user.name : "Not Logged In";
-  const userId = session?.user?.id ? session.user.id : "Not Logged In";
+
 
   return (
     <StyledEngineProvider injectFirst>
@@ -62,30 +59,7 @@ export default async function RootLayout({
               strategy="beforeInteractive"
             />
             <HubspotTracking session={session} />
-            <Script id="pendo-script" strategy="afterInteractive">
-              {`
-								(function(apiKey){
-										(function(p,e,n,d,o){var v,w,x,y,z;o=p[d]=p[d]||{};o._q=o._q||[];
-										v=['initialize','identify','updateOptions','pageLoad','track'];for(w=0,x=v.length;w<x;++w)(function(m){
-												o[m]=o[m]||function(){o._q[m===v[0]?'unshift':'push']([m].concat([].slice.call(arguments,0)));};})(v[w]);
-												y=e.createElement(n);y.async=!0;y.src='https://cdn.pendo.io/agent/static/'+apiKey+'/pendo.js';
-												z=e.getElementsByTagName(n)[0];z.parentNode.insertBefore(y,z);})(window,document,'script','pendo');
-
-										pendo.initialize({
-												visitor: {
-														id: "${userId}",
-														email: "${emailAddress}",
-														firstName: "${name}",
-												},
-
-												account: {
-														id: "${process.env.PENDO_ACCOUNT_ID}",
-														accountName: "SIR Digital Hub",
-												}
-										});
-								})('${process.env.PENDO_API_KEY}');
-							`}
-            </Script>
+            <PendoScript session={session} />
           </body>
           <GoogleAnalytics gaId="G-L7T5ZQH0G5" />
         </html>


### PR DESCRIPTION
Abstracted Pendo Initialization into its own component The errant behavior was that user data was only sometimes being passed into the Pendo initialization. Alternatively, this approach only adds the Pendo initialization script to the document after `session` has been populated by NextAuth, ensuring that the user data is returned by the time that Pendo is loaded.

I'm not sure what is returned from NextAuth when there is no active session available. The `PendoScript` component might have to be updated so that if no session is available, Pendo will still initialize.