### PR TITLE
Separate pendo instatiation from initialization, pass in env variable

### DIFF
--- a/app/components/Pendo/embed.ts
+++ b/app/components/Pendo/embed.ts
@@ -2,7 +2,7 @@
 
 import { useEffect } from "react";
 
-export default function PendoScript({ session }: any) {
+export default function PendoScript({ session, pendoAccountId }: any) {
   useEffect(() => {
     if (session) {
       const emailAddress = session?.user?.email
@@ -17,13 +17,6 @@ export default function PendoScript({ session }: any) {
       script.async = true;
       script.defer = true;
       script.innerHTML = `
-        (function(apiKey){
-          (function(p,e,n,d,o){var v,w,x,y,z;o=p[d]=p[d]||{};o._q=o._q||[];
-          v=['initialize','identify','updateOptions','pageLoad','track'];for(w=0,x=v.length;w<x;++w)(function(m){
-            o[m]=o[m]||function(){o._q[m===v[0]?'unshift':'push']([m].concat([].slice.call(arguments,0)));};})(v[w]);
-            y=e.createElement(n);y.async=!0;y.src='https://cdn.pendo.io/agent/static/'+apiKey+'/pendo.js';
-            z=e.getElementsByTagName(n)[0];z.parentNode.insertBefore(y,z);})(window,document,'script','pendo');
-
           pendo.initialize({
             visitor: {
               id: "${userId}",
@@ -31,11 +24,10 @@ export default function PendoScript({ session }: any) {
               firstName: "${name}",
             },
             account: {
-              id: "${process.env.PENDO_ACCOUNT_ID}",
+              id: "${pendoAccountId}",
               accountName: "SIR Digital Hub",
             }
           });
-        })('${process.env.PENDO_API_KEY}');
       `;
       document.body.appendChild(script);
     }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -59,7 +59,18 @@ export default async function RootLayout({
               strategy="beforeInteractive"
             />
             <HubspotTracking session={session} />
-            <PendoScript session={session} />
+            <Script id="pendo-script" strategy="afterInteractive">
+              {`
+								(function(apiKey){
+										(function(p,e,n,d,o){var v,w,x,y,z;o=p[d]=p[d]||{};o._q=o._q||[];
+										v=['initialize','identify','updateOptions','pageLoad','track'];for(w=0,x=v.length;w<x;++w)(function(m){
+												o[m]=o[m]||function(){o._q[m===v[0]?'unshift':'push']([m].concat([].slice.call(arguments,0)));};})(v[w]);
+												y=e.createElement(n);y.async=!0;y.src='https://cdn.pendo.io/agent/static/'+apiKey+'/pendo.js';
+												z=e.getElementsByTagName(n)[0];z.parentNode.insertBefore(y,z);})(window,document,'script','pendo');
+                        })('${process.env.PENDO_API_KEY}');
+							`}
+            </Script>
+            <PendoScript session={session} pendoAccountId={process.env.PENDO_ACCOUNT_ID} />
           </body>
           <GoogleAnalytics gaId="G-L7T5ZQH0G5" />
         </html>


### PR DESCRIPTION
Hi @kblizeck ,

I checked the site to see if data was flowing into Pendo and I realized I made two mistakes.

1. I didnt realize that env variables were not accessible inside the `PendoScript` component. I've fixed this by passing in the ID.
2. I separated the two sections of the pendo JS. Now the `function(p,e,n,d,o)` will run to instantiate pendo in the window. Then in the `PendoScript` component, the second part of the script will run which will tie the session to a user once they've logged in.

Thanks for your patience with this.